### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Swift实现的UILabel文字随机渐隐渐现, Swift版RQShineLabel.
 
 暂时没做Pod和Carthage.
 
-###基础使用Demo：
+### 基础使用Demo：
 
 ```
 	let blingBlingLabel = FNBlingBlingLabel.init(frame: CGRectMake(0, 0, 300, 200))
@@ -16,8 +16,8 @@ Swift实现的UILabel文字随机渐隐渐现, Swift版RQShineLabel.
 	blingBlingLabel.text = "FNBlingBlingLabel-TestString"
 ```
 
-###效果：
+### 效果：
 ![Animating](readme_images/animating.gif)
 
-###来源：
+### 来源：
 OC原版是 [RQShineLabel](https://github.com/zipme/RQShineLabel)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
